### PR TITLE
remove redundant version information

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
 	"name": "utf8",
-	"version": "2.0.0",
 	"main": "utf8.js",
 	"ignore": [
 		"coverage",


### PR DESCRIPTION
that is easily forgotten when updating and resolves in `bower utf8#*  mismatch Version declared in the json (2.0.0) is different than the resolved one (2.1.2)` from bower. Better leave that out :)